### PR TITLE
Raincatch 629

### DIFF
--- a/lib/mediator-service/index.js
+++ b/lib/mediator-service/index.js
@@ -1,32 +1,8 @@
 var CONSTANTS = require('../constants');
-var shortid = require('shortid');
-var q = require('q');
 var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
 
-/**
- *
- * Getting Promises for done and error topics.
- * This will resolve or reject the reuturned promise depending on the topic published.
- *
- * @param doneTopicPromise  - A promise for the done topic.
- * @param errorTopicPromise - A promise for the error topic.
- * @returns {Promise}
- */
-function getTopicPromises(doneTopicPromise, errorTopicPromise) {
-  var deferred = q.defer();
-
-  doneTopicPromise.then(function(createdWorkorder) {
-    deferred.resolve(createdWorkorder);
-  });
-
-  errorTopicPromise.then(function(error) {
-    deferred.reject(error);
-  });
-
-  return deferred.promise;
-}
-
-
+var shortid = require('shortid');
+// var q = require('q');
 
 /**
  *
@@ -51,42 +27,12 @@ function WorkorderMediatorService(mediator, config) {
 
 /**
  *
- * Getting Promises for the done and error topics.
- *
- * @param {MediatorTopicUtility} topicGenerator
- * @param {string} topicName   - The name of the topic to generate
- * @param {string} [topicUid]  - A topic UID if required.
- * @returns {Promise} - A promise for the topic.
- */
-WorkorderMediatorService.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(topicGenerator, topicName, topicUid) {
-  var doneTopic = topicGenerator.getTopic(topicName, CONSTANTS.DONE_PREFIX, topicUid);
-  var errorTopic = topicGenerator.getTopic(topicName, CONSTANTS.ERROR_PREFIX, topicUid);
-
-  var doneTopicPromise = topicGenerator.mediator.promise(doneTopic);
-  var errorTopicPromise = topicGenerator.mediator.promise(errorTopic);
-
-  var timeoutDefer = q.defer();
-
-  setTimeout(function() {
-    timeoutDefer.reject(new Error("Timeout For Topic: " + doneTopic));
-  }, this.config.topicTimeout || CONSTANTS.TOPIC_TIMEOUT);
-
-  //Either one of these promises resolves/rejects or it will time out.
-  return q.race([getTopicPromises(doneTopicPromise, errorTopicPromise), timeoutDefer.promise]);
-};
-
-/**
- *
  * Listing all workorders
  *
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.listWorkorders = function listWorkorders() {
-  var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.LIST);
-
-  this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.LIST));
-
-  return promise;
+  return this.workordersTopics.execute(CONSTANTS.TOPICS.LIST, this.config);
 };
 
 
@@ -98,14 +44,11 @@ WorkorderMediatorService.prototype.listWorkorders = function listWorkorders() {
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.readWorkorder = function readWorkorder(workorderId) {
-  var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.READ, workorderId);
-
-  this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.READ), {
+  var payload = {
     id: workorderId,
     topicUid: workorderId
-  });
-
-  return promise;
+  };
+  return this.workordersTopics.execute(CONSTANTS.TOPICS.READ, this.config, payload);
 };
 
 /**
@@ -116,16 +59,11 @@ WorkorderMediatorService.prototype.readWorkorder = function readWorkorder(workor
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.createWorkorder = function createWorkorder(workorderToCreate) {
-  var topicUid = shortid.generate();
-
-  var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.CREATE, topicUid);
-
-  this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.CREATE), {
+  var payload = {
     workorderToCreate: workorderToCreate,
-    topicUid: topicUid
-  });
-
-  return promise;
+    topicUid: shortid.generate()
+  };
+  return workordersTopics.execute(CONSTANTS.TOPICS.CREATE, this.config, payload);
 };
 
 /**
@@ -137,15 +75,11 @@ WorkorderMediatorService.prototype.createWorkorder = function createWorkorder(wo
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.updateWorkorder = function updateWorkorder(workorderToUpdate) {
-
-  var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.UPDATE, workorderToUpdate.id);
-
-  this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.UPDATE), {
+  var payload = {
     workorderToUpdate: workorderToUpdate,
     topicUid: workorderToUpdate.id
-  });
-
-  return promise;
+  };
+  return workordersTopics.execute(CONSTANTS.TOPICS.UPDATE, this.config, payload);
 };
 
 /**
@@ -157,15 +91,11 @@ WorkorderMediatorService.prototype.updateWorkorder = function updateWorkorder(wo
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.removeWorkorder = function removeWorkorder(workorderToRemove) {
-
-  var promise = this.getErrorAndDoneTopicPromises(this.workordersTopics, CONSTANTS.TOPICS.REMOVE, workorderToRemove.id);
-
-  this.mediator.publish(this.workordersTopics.getTopic(CONSTANTS.TOPICS.REMOVE), {
+  var payload = {
     id: workorderToRemove.id,
     topicUid: workorderToRemove.id
-  });
-
-  return promise;
+  };
+  return workordersTopics.execute(CONSTANTS.TOPICS.REMOVE, this.config, payload);
 };
 
 /**
@@ -175,11 +105,7 @@ WorkorderMediatorService.prototype.removeWorkorder = function removeWorkorder(wo
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.listWorkflows = function listWorkflows() {
-  var promise = this.getErrorAndDoneTopicPromises(this.workflowsTopics, CONSTANTS.TOPICS.LIST);
-
-  this.mediator.publish(this.workflowsTopics.getTopic(CONSTANTS.TOPICS.LIST));
-
-  return promise;
+  return workflowsTopics.execute(CONSTANTS.TOPICS.LIST, this.config, payload);
 };
 
 
@@ -189,11 +115,11 @@ WorkorderMediatorService.prototype.listWorkflows = function listWorkflows() {
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.readWorkflow = function readWorkflow(workflowId) {
-  var promise = this.getErrorAndDoneTopicPromises(this.workflowsTopics, CONSTANTS.TOPICS.READ, workflowId);
-
-  this.mediator.publish(this.workflowsTopics.getTopic(CONSTANTS.TOPICS.READ), {id: workflowId, topicUid: workflowId});
-
-  return promise;
+  var payload = {
+    id: workflowId,
+    topicUid: workflowId
+  };
+  return workflowsTopics.execute(CONSTANTS.TOPICS.READ, this.config, payload);
 };
 
 /**
@@ -203,11 +129,7 @@ WorkorderMediatorService.prototype.readWorkflow = function readWorkflow(workflow
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.listResults = function listResults() {
-  var promise = this.getErrorAndDoneTopicPromises(this.resultsTopics, CONSTANTS.TOPICS.LIST);
-
-  this.mediator.publish(this.resultsTopics.getTopic(CONSTANTS.TOPICS.LIST));
-
-  return promise;
+  return resultsTopics.execute(CONSTANTS.TOPICS.LIST, this.config, payload);
 };
 
 /**
@@ -218,11 +140,11 @@ WorkorderMediatorService.prototype.listResults = function listResults() {
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.readUser = function readUser(userId) {
-  var promise = this.getErrorAndDoneTopicPromises(this.usersTopics, CONSTANTS.TOPICS.READ, userId);
-
-  this.mediator.publish(this.usersTopics.getTopic(CONSTANTS.TOPICS.READ), {id: userId, topicUid: userId});
-
-  return promise;
+  var payload = {
+    id: userId,
+    topicUid: userId
+  };
+  return usersTopics.execute(CONSTANTS.TOPICS.READ, this.config, payload);
 };
 
 /**
@@ -232,11 +154,7 @@ WorkorderMediatorService.prototype.readUser = function readUser(userId) {
  * @returns {Promise}
  */
 WorkorderMediatorService.prototype.listUsers = function listUsers() {
-  var promise = this.getErrorAndDoneTopicPromises(this.usersTopics, CONSTANTS.TOPICS.LIST);
-
-  this.mediator.publish(this.usersTopics.getTopic(CONSTANTS.TOPICS.LIST));
-
-  return promise;
+  return usersTopics.execute(CONSTANTS.TOPICS.LIST, this.config, payload);
 };
 
 /**

--- a/lib/sync-service/client.js
+++ b/lib/sync-service/client.js
@@ -22,7 +22,7 @@ var mediator, manager, workorderSyncSubscribers;
  * @param errorTopicPromise - A promise for the error topic.
  * @returns {*}
  */
-function getTopicPromises(doneTopicPromise, errorTopicPromise) {
+/*function getTopicPromises(doneTopicPromise, errorTopicPromise) {
   var deferred = q.defer();
 
   doneTopicPromise.then(function(createdWorkorder) {
@@ -34,7 +34,7 @@ function getTopicPromises(doneTopicPromise, errorTopicPromise) {
   });
 
   return deferred.promise;
-}
+}*/
 
 
 /**
@@ -56,7 +56,8 @@ function create(workorderToCreate) {
 
   mediator.publish(workorderSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), topicParams);
 
-  return getTopicPromises(donePromise, errorPromise);
+  //return getTopicPromises(donePromise, errorPromise);
+  return workorderSyncSubscribers.getTopicPromises(donePromise, errorPromise);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "angular-material": "1.0.7",
     "angular-messages": "1.5.3",
     "angular-ui-router": "0.2.18",
-    "fh-wfm-mediator": "0.2.0-0",
+    "express": "4.14.0",
+    "fh-wfm-mediator": "0.4.0-alpha.629.4",
     "lodash": "4.7.0",
     "q": "1.4.1",
     "shortid": "2.2.6"


### PR DESCRIPTION
Part of https://issues.jboss.org/browse/RAINCATCH-629  

Moves getTopicPromises & getErrorAndDoneTopicPromises out of raincatcher-workorder-angular module, and refactors code to call this functionality via execute() method in updated version of mediator (https://github.com/feedhenry-raincatcher/raincatcher-mediator/pull/23)