### PR TITLE
Switch Finish Date and Time To Start Date

### DIFF
--- a/dist/workorder-form.tpl.html.js
+++ b/dist/workorder-form.tpl.html.js
@@ -110,6 +110,25 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '  </md-input-container>\n' +
     '</div>\n' +
     '\n' +
+    '<div layout-gt-sm="row">\n' +
+    '    <md-input-container class="md-block" flex-gt-sm>\n' +
+    '        <label for="inputFinishDate">Finish Date</label>\n' +
+    '        <input type="date"  id="inputFinishDate" name="finishDate" min="{{today}}" max="{{maxDate}}" ng-model="ctrl.model.finishDate" required>\n' +
+    '        <div ng-messages="workorderForm.finishDate.$error" ng-show="ctrl.submitted || workorderForm.finishDate.$dirty">\n' +
+    '            <div ng-message="required">A finish date is required.</div>\n' +
+    '            <div ng-message="min">Finish Date should not be less than current date.</div>\n' +
+    '            <div ng-message="max">Finish Date is too far in the future.</div>\n' +
+    '        </div>\n' +
+    '    </md-input-container>\n' +
+    '    <md-input-container class="md-block" flex-gt-sm>\n' +
+    '        <label for="inputFinishTime" >Finish Time</label>\n' +
+    '        <input type="time"  id="inputFinishTime" name="finishTime"  ng-model="ctrl.model.finishTime" required>\n' +
+    '        <div ng-messages="workorderForm.finishTime.$error" ng-show="ctrl.submitted || workorderForm.finishTime.$dirty">\n' +
+    '            <div ng-message="required">A finish time is required.</div>\n' +
+    '        </div>\n' +
+    '    </md-input-container>\n' +
+    '</div>\n' +
+    '\n' +
     '<div>\n' +
     '  <md-input-container class="md-block" ng-class="{ \'has-error\' : workorderForm.summary.$invalid && !workorderForm.summary.$pristine }">\n' +
     '    <label for="inputSummary">Summary</label>\n' +

--- a/dist/workorder-form.tpl.html.js
+++ b/dist/workorder-form.tpl.html.js
@@ -93,19 +93,19 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '\n' +
     '<div layout-gt-sm="row">\n' +
     '  <md-input-container class="md-block" flex-gt-sm>\n' +
-    '    <label for="inputFinishDate">Finish Date</label>\n' +
-    '    <input type="date"  id="inputFinishDate" name="finishDate" min="{{today}}" max="{{maxDate}}" ng-model="ctrl.model.finishDate" required>\n' +
-    '    <div ng-messages="workorderForm.finishDate.$error" ng-show="ctrl.submitted || workorderForm.finishDate.$dirty">\n' +
-    '      <div ng-message="required">A finish date is required.</div>\n' +
+    '    <label for="inputStartDate">Start Date</label>\n' +
+    '    <input type="date"  id="inputStartDate" name="startDate" min="{{today}}" max="{{maxDate}}" ng-model="ctrl.model.startDate" required>\n' +
+    '    <div ng-messages="workorderForm.startDate.$error" ng-show="ctrl.submitted || workorderForm.startDate.$dirty">\n' +
+    '      <div ng-message="required">A start date is required.</div>\n' +
     '      <div ng-message="min">Start Date should not be less than current date.</div>\n' +
     '      <div ng-message="max">Start Date is too far in the future.</div>\n' +
     '    </div>\n' +
     '  </md-input-container>\n' +
     '  <md-input-container class="md-block" flex-gt-sm>\n' +
-    '    <label for="inputFinishTime" >Finish Time</label>\n' +
-    '    <input type="time"  id="inputFinishTime" name="finishTime"  ng-model="ctrl.model.finishTime" required>\n' +
-    '    <div ng-messages="workorderForm.finishTime.$error" ng-show="ctrl.submitted || workorderForm.finishTime.$dirty">\n' +
-    '      <div ng-message="required">A finish time is required.</div>\n' +
+    '    <label for="inputStartTime" >Start Time</label>\n' +
+    '    <input type="time"  id="inputStartTime" name="startTime"  ng-model="ctrl.model.startTime" required>\n' +
+    '    <div ng-messages="workorderForm.startTime.$error" ng-show="ctrl.submitted || workorderForm.startTime.$dirty">\n' +
+    '      <div ng-message="required">A start time is required.</div>\n' +
     '    </div>\n' +
     '  </md-input-container>\n' +
     '</div>\n' +

--- a/dist/workorder.tpl.html.js
+++ b/dist/workorder.tpl.html.js
@@ -53,7 +53,7 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '      <md-icon md-font-set="material-icons">event</md-icon>\n' +
     '      <div class="md-list-item-text">\n' +
     '        <h3>{{workorder.startTimestamp | date:\'yyyy-MM-dd\' }}</h3>\n' +
-    '        <p>Finish Date</p>\n' +
+    '        <p>Start Date</p>\n' +
     '      </div>\n' +
     '    </md-list-item>\n' +
     '    <md-divider></md-divider>\n' +
@@ -62,6 +62,24 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '      <md-icon md-font-set="material-icons">schedule</md-icon>\n' +
     '      <div class="md-list-item-text">\n' +
     '        <h3>{{workorder.startTimestamp | date:\'HH:mm:ss Z\' }}</h3>\n' +
+    '        <p>Start Time</p>\n' +
+    '      </div>\n' +
+    '    </md-list-item>\n' +
+    '    <md-divider></md-divider>\n' +
+    '\n' +
+    '    <md-list-item class="md-2-line" ng-if="workorder.finishTimestamp">\n' +
+    '      <md-icon md-font-set="material-icons">event</md-icon>\n' +
+    '      <div class="md-list-item-text">\n' +
+    '        <h3>{{workorder.finishTimestamp | date:\'yyyy-MM-dd\' }}</h3>\n' +
+    '        <p>Finish Date</p>\n' +
+    '      </div>\n' +
+    '    </md-list-item>\n' +
+    '    <md-divider></md-divider>\n' +
+    '\n' +
+    '    <md-list-item class="md-2-line" ng-if="workorder.finishTimestamp" >\n' +
+    '      <md-icon md-font-set="material-icons">schedule</md-icon>\n' +
+    '      <div class="md-list-item-text">\n' +
+    '        <h3>{{workorder.finishTimestamp | date:\'HH:mm:ss Z\' }}</h3>\n' +
     '        <p>Finish Time</p>\n' +
     '      </div>\n' +
     '    </md-list-item>\n' +

--- a/lib/template/workorder-form.tpl.html
+++ b/lib/template/workorder-form.tpl.html
@@ -101,6 +101,25 @@
   </md-input-container>
 </div>
 
+<div layout-gt-sm="row">
+    <md-input-container class="md-block" flex-gt-sm>
+        <label for="inputFinishDate">Finish Date</label>
+        <input type="date"  id="inputFinishDate" name="finishDate" min="{{today}}" max="{{maxDate}}" ng-model="ctrl.model.finishDate" required>
+        <div ng-messages="workorderForm.finishDate.$error" ng-show="ctrl.submitted || workorderForm.finishDate.$dirty">
+            <div ng-message="required">A finish date is required.</div>
+            <div ng-message="min">Finish Date should not be less than current date.</div>
+            <div ng-message="max">Finish Date is too far in the future.</div>
+        </div>
+    </md-input-container>
+    <md-input-container class="md-block" flex-gt-sm>
+        <label for="inputFinishTime" >Finish Time</label>
+        <input type="time"  id="inputFinishTime" name="finishTime"  ng-model="ctrl.model.finishTime" required>
+        <div ng-messages="workorderForm.finishTime.$error" ng-show="ctrl.submitted || workorderForm.finishTime.$dirty">
+            <div ng-message="required">A finish time is required.</div>
+        </div>
+    </md-input-container>
+</div>
+
 <div>
   <md-input-container class="md-block" ng-class="{ 'has-error' : workorderForm.summary.$invalid && !workorderForm.summary.$pristine }">
     <label for="inputSummary">Summary</label>

--- a/lib/template/workorder-form.tpl.html
+++ b/lib/template/workorder-form.tpl.html
@@ -84,19 +84,19 @@
 
 <div layout-gt-sm="row">
   <md-input-container class="md-block" flex-gt-sm>
-    <label for="inputFinishDate">Finish Date</label>
-    <input type="date"  id="inputFinishDate" name="finishDate" min="{{today}}" max="{{maxDate}}" ng-model="ctrl.model.finishDate" required>
-    <div ng-messages="workorderForm.finishDate.$error" ng-show="ctrl.submitted || workorderForm.finishDate.$dirty">
-      <div ng-message="required">A finish date is required.</div>
+    <label for="inputStartDate">Start Date</label>
+    <input type="date"  id="inputStartDate" name="startDate" min="{{today}}" max="{{maxDate}}" ng-model="ctrl.model.startDate" required>
+    <div ng-messages="workorderForm.startDate.$error" ng-show="ctrl.submitted || workorderForm.startDate.$dirty">
+      <div ng-message="required">A start date is required.</div>
       <div ng-message="min">Start Date should not be less than current date.</div>
       <div ng-message="max">Start Date is too far in the future.</div>
     </div>
   </md-input-container>
   <md-input-container class="md-block" flex-gt-sm>
-    <label for="inputFinishTime" >Finish Time</label>
-    <input type="time"  id="inputFinishTime" name="finishTime"  ng-model="ctrl.model.finishTime" required>
-    <div ng-messages="workorderForm.finishTime.$error" ng-show="ctrl.submitted || workorderForm.finishTime.$dirty">
-      <div ng-message="required">A finish time is required.</div>
+    <label for="inputStartTime" >Start Time</label>
+    <input type="time"  id="inputStartTime" name="startTime"  ng-model="ctrl.model.startTime" required>
+    <div ng-messages="workorderForm.startTime.$error" ng-show="ctrl.submitted || workorderForm.startTime.$dirty">
+      <div ng-message="required">A start time is required.</div>
     </div>
   </md-input-container>
 </div>

--- a/lib/template/workorder.tpl.html
+++ b/lib/template/workorder.tpl.html
@@ -44,7 +44,7 @@
       <md-icon md-font-set="material-icons">event</md-icon>
       <div class="md-list-item-text">
         <h3>{{workorder.startTimestamp | date:'yyyy-MM-dd' }}</h3>
-        <p>Finish Date</p>
+        <p>Start Date</p>
       </div>
     </md-list-item>
     <md-divider></md-divider>
@@ -53,6 +53,24 @@
       <md-icon md-font-set="material-icons">schedule</md-icon>
       <div class="md-list-item-text">
         <h3>{{workorder.startTimestamp | date:'HH:mm:ss Z' }}</h3>
+        <p>Start Time</p>
+      </div>
+    </md-list-item>
+    <md-divider></md-divider>
+
+    <md-list-item class="md-2-line" ng-if="workorder.finishTimestamp">
+      <md-icon md-font-set="material-icons">event</md-icon>
+      <div class="md-list-item-text">
+        <h3>{{workorder.finishTimestamp | date:'yyyy-MM-dd' }}</h3>
+        <p>Finish Date</p>
+      </div>
+    </md-list-item>
+    <md-divider></md-divider>
+
+    <md-list-item class="md-2-line" ng-if="workorder.finishTimestamp" >
+      <md-icon md-font-set="material-icons">schedule</md-icon>
+      <div class="md-list-item-text">
+        <h3>{{workorder.finishTimestamp | date:'HH:mm:ss Z' }}</h3>
         <p>Finish Time</p>
       </div>
     </md-list-item>

--- a/lib/workorder-form/workorder-form-controller.js
+++ b/lib/workorder-form/workorder-form-controller.js
@@ -55,7 +55,6 @@ function WorkorderFormController($scope, mediator, workorderMediatorService, $st
         self.model.finishTime.getMinutes(),
         self.model.finishTime.getSeconds()
       );
-      
       var workorderToCreate = JSON.parse(angular.toJson(self.model));
 
       var createUpdatePromise;

--- a/lib/workorder-form/workorder-form-controller.js
+++ b/lib/workorder-form/workorder-form-controller.js
@@ -47,9 +47,15 @@ function WorkorderFormController($scope, mediator, workorderMediatorService, $st
       self.model.startTimestamp.setHours(
         self.model.startTime.getHours(),
         self.model.startTime.getMinutes(),
-        self.model.startTime.getSeconds(),
-        self.model.startTime.getMilliseconds()
+        self.model.startTime.getSeconds()
       );
+      self.model.finishTimestamp = new Date(self.model.finishDate);
+      self.model.finishTimestamp.setHours(
+        self.model.finishTime.getHours(),
+        self.model.finishTime.getMinutes(),
+        self.model.finishTime.getSeconds()
+      );
+      
       var workorderToCreate = JSON.parse(angular.toJson(self.model));
 
       var createUpdatePromise;
@@ -77,6 +83,10 @@ function WorkorderFormController($scope, mediator, workorderMediatorService, $st
     if (self.model && self.model.startTimestamp) {
       self.model.startDate = new Date(self.model.startTimestamp);
       self.model.startTime = new Date(self.model.startTimestamp);
+      self.model.startTime.setMilliseconds(0);
+      self.model.finishDate = new Date(self.model.finishTimestamp);
+      self.model.finishTime = new Date(self.model.finishTimestamp);
+      self.model.finishTime.setMilliseconds(0);
     }
   });
 }

--- a/lib/workorder-form/workorder-form-controller.js
+++ b/lib/workorder-form/workorder-form-controller.js
@@ -26,7 +26,7 @@ function WorkorderFormController($scope, mediator, workorderMediatorService, $st
   //Need workorder, workflows, workers
 
   //If there is a workorder ID in the state URL, then we are editing a worokorder, otherwise we are creating a new one.
-  var workorderPromise = $stateParams.workorderId ? workorderMediatorService.readWorkorder($stateParams.workorderId) : $q.when({});
+  var workorderPromise = $stateParams.workorderId ? workorderMediatorService.readWorkorder($stateParams.workorderId) : $q.when({location: []});
   var workflowsPromise = workorderMediatorService.listWorkflows();
   var workersPromise = workorderMediatorService.listUsers();
 

--- a/lib/workorder-form/workorder-form-controller.js
+++ b/lib/workorder-form/workorder-form-controller.js
@@ -40,19 +40,16 @@ function WorkorderFormController($scope, mediator, workorderMediatorService, $st
     event.stopPropagation();
   };
 
-  //TODO: Should reaally be a service
   self.done = function(isValid) {
     self.submitted = true;
     if (isValid) {
-      self.model.startTimestamp = new Date(self.model.finishDate); // TODO: incorporate self.model.finishTime
+      self.model.startTimestamp = new Date(self.model.startDate);
       self.model.startTimestamp.setHours(
-        self.model.finishTime.getHours(),
-        self.model.finishTime.getMinutes(),
-        self.model.finishTime.getSeconds(),
-        self.model.finishTime.getMilliseconds()
+        self.model.startTime.getHours(),
+        self.model.startTime.getMinutes(),
+        self.model.startTime.getSeconds(),
+        self.model.startTime.getMilliseconds()
       );
-      self.model.finishDate = new Date(self.model.startTimestamp);
-      self.model.finishTime = new Date(self.model.startTimestamp);
       var workorderToCreate = JSON.parse(angular.toJson(self.model));
 
       var createUpdatePromise;
@@ -78,8 +75,8 @@ function WorkorderFormController($scope, mediator, workorderMediatorService, $st
 
 
     if (self.model && self.model.startTimestamp) {
-      self.model.finishDate = new Date(self.model.startTimestamp);
-      self.model.finishTime = new Date(self.model.startTimestamp);
+      self.model.startDate = new Date(self.model.startTimestamp);
+      self.model.startTime = new Date(self.model.startTimestamp);
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workorder-angular",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Angular UI Implementation of Workorders",
   "main": "lib/workorder-ng.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workorder-angular",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Angular UI Implementation of Workorders",
   "main": "lib/workorder-ng.js",
   "scripts": {


### PR DESCRIPTION
# Motivation

When creating / updating a workorder, the `start` date and time of the workorder should be assigned.

Currently, it is assigning the `finish` date and time to the workorder.

# Changes

 - Switched `finishDate` and `finishTime` to `startDate` and `startTime`
 - Added new display fields `finishTimestamp`.